### PR TITLE
add akka CLI install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ The Flight Training Scheduler project serves as the certification test for Akka 
 * Apache Maven version 3.9 or later
 * `curl` command-line tool
 
-Clone this template repository, which contains:
+Download the Akka CLI following the instructions [here](https://doc.akka.io/operations/cli/installation.html), and create any example project by running
+
+```shell
+akka code init
+```
+
+This will add your `repo.akka.io` token to your local user account's [Maven `settings.xml` file](https://maven.apache.org/settings.html).
+
+Then, clone this template repository, which contains:
 
 * Project structure and configuration
 * Documentation and requirements


### PR DESCRIPTION
It is a necessary prerequisite to install the Akka CLI to compile this project.

This PR adds instructions for installing the Akka CLI to the README file.