### PR TITLE
docs: adding agent requirement and docs consistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.akka</groupId>
     <artifactId>akka-javasdk-parent</artifactId>
-    <version>3.3.0</version>
+    <version>3.5.6</version>
   </parent>
   
   <groupId>io.example</groupId>

--- a/src/main/java/io/example/api/FlightEndpoint.java
+++ b/src/main/java/io/example/api/FlightEndpoint.java
@@ -39,6 +39,9 @@ public class FlightEndpoint extends AbstractHttpEndpoint {
 
         // Implementation here
 
+        // Make sure to get a flight conditions report from the AI agent and use that
+        // to decide if the booking can be created
+
         return HttpResponses.created();
     }
 

--- a/src/main/java/io/example/application/BookingSlotEntity.java
+++ b/src/main/java/io/example/application/BookingSlotEntity.java
@@ -1,18 +1,17 @@
 package io.example.application;
 
 import akka.Done;
-import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Component;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import io.example.domain.BookingEvent;
 import io.example.domain.Participant;
 import io.example.domain.Timeslot;
 import java.util.HashSet;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ComponentId("booking-slot")
+@Component(id = "booking-slot")
 public class BookingSlotEntity extends EventSourcedEntity<Timeslot, BookingEvent> {
 
     private final String entityId;

--- a/src/main/java/io/example/application/FlightConditionsAgent.java
+++ b/src/main/java/io/example/application/FlightConditionsAgent.java
@@ -1,0 +1,49 @@
+package io.example.application;
+
+import akka.javasdk.agent.Agent;
+import akka.javasdk.annotations.Component;
+import akka.javasdk.annotations.FunctionTool;
+
+/*
+ * The flight conditions agent is responsible for making a determination about the flight
+ * conditions for a given day and time. You will need to clearly define the success criteria
+ * for the report and instruct the agent (in the system prompt) about the schema of
+ * the results it must return (the ConditionsReport).
+ *
+ * Also be sure to provide clear instructions on how and when tools should be invoked
+ * in order to generate results.
+ *
+ * Flight conditions criteria don't need to be exhaustive, but you should supply the
+ * criteria so that an agent does not need to make an external HTTP call to query
+ * the condition limits.
+ */
+
+@Component(id = "flight-conditions-agent")
+public class FlightConditionsAgent extends Agent {
+
+    record ConditionsReport(String timeSlotId, Boolean meetsRequirements) {
+    }
+
+    private static final String SYSTEM_MESSAGE = """
+            You are an agent responsible for evaluating flight conditions...
+            """.stripIndent();
+
+    public Effect<ConditionsReport> query(String timeSlotId) {
+        return effects().systemMessage(SYSTEM_MESSAGE)
+                .userMessage("Validate the conditions...")
+                .responseAs(ConditionsReport.class)
+                .thenReply();
+    }
+
+    /*
+     * You can choose to hard code the weather conditions for specific days or you
+     * can actually
+     * communicate with an external weather API. You should be able to get both
+     * suitable weather
+     * conditions and poor weather conditions from this tool function for testing.
+     */
+    @FunctionTool(description = "Queries the weather conditions as they are forecasted based on the time slot ID of the training session booking")
+    private String getWeatherForecast(String timeSlotId) {
+        return "queried or mock weather conditions.";
+    }
+}

--- a/src/main/java/io/example/application/ParticipantSlotEntity.java
+++ b/src/main/java/io/example/application/ParticipantSlotEntity.java
@@ -1,86 +1,86 @@
 package io.example.application;
 
 import akka.Done;
-import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.TypeName;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import io.example.domain.Participant.ParticipantType;
 
-@ComponentId("participant-slot")
+@Component(id = "participant-slot")
 public class ParticipantSlotEntity
-        extends EventSourcedEntity<ParticipantSlotEntity.State, ParticipantSlotEntity.Event> {
+                extends EventSourcedEntity<ParticipantSlotEntity.State, ParticipantSlotEntity.Event> {
 
-    public Effect<Done> unmarkAvailable(ParticipantSlotEntity.Commands.UnmarkAvailable unmark) {
-        // Supply your own implementation
-        return effects().reply(Done.done());
-    }
-
-    public Effect<Done> markAvailable(ParticipantSlotEntity.Commands.MarkAvailable mark) {
-        // Supply your own implementation
-        return effects().reply(Done.done());
-    }
-
-    public Effect<Done> book(ParticipantSlotEntity.Commands.Book book) {
-        // Supply your own implementation
-        return effects().reply(Done.done());
-    }
-
-    public Effect<Done> cancel(ParticipantSlotEntity.Commands.Cancel cancel) {
-        // Supply your own implementation
-        return effects().reply(Done.done());
-    }
-
-    record State(
-            String slotId, String participantId, ParticipantType participantType, String status) {
-    }
-
-    public sealed interface Commands {
-        record MarkAvailable(String slotId, String participantId, ParticipantType participantType)
-                implements Commands {
+        public Effect<Done> unmarkAvailable(ParticipantSlotEntity.Commands.UnmarkAvailable unmark) {
+                // Supply your own implementation
+                return effects().reply(Done.done());
         }
 
-        record UnmarkAvailable(String slotId, String participantId, ParticipantType participantType)
-                implements Commands {
+        public Effect<Done> markAvailable(ParticipantSlotEntity.Commands.MarkAvailable mark) {
+                // Supply your own implementation
+                return effects().reply(Done.done());
         }
 
-        record Book(
-                String slotId, String participantId, ParticipantType participantType, String bookingId)
-                implements Commands {
+        public Effect<Done> book(ParticipantSlotEntity.Commands.Book book) {
+                // Supply your own implementation
+                return effects().reply(Done.done());
         }
 
-        record Cancel(
-                String slotId, String participantId, ParticipantType participantType, String bookingId)
-                implements Commands {
-        }
-    }
-
-    public sealed interface Event {
-        @TypeName("marked-available")
-        record MarkedAvailable(String slotId, String participantId, ParticipantType participantType)
-                implements Event {
+        public Effect<Done> cancel(ParticipantSlotEntity.Commands.Cancel cancel) {
+                // Supply your own implementation
+                return effects().reply(Done.done());
         }
 
-        @TypeName("unmarked-available")
-        record UnmarkedAvailable(String slotId, String participantId, ParticipantType participantType)
-                implements Event {
+        record State(
+                        String slotId, String participantId, ParticipantType participantType, String status) {
         }
 
-        @TypeName("participant-booked")
-        record Booked(
-                String slotId, String participantId, ParticipantType participantType, String bookingId)
-                implements Event {
+        public sealed interface Commands {
+                record MarkAvailable(String slotId, String participantId, ParticipantType participantType)
+                                implements Commands {
+                }
+
+                record UnmarkAvailable(String slotId, String participantId, ParticipantType participantType)
+                                implements Commands {
+                }
+
+                record Book(
+                                String slotId, String participantId, ParticipantType participantType, String bookingId)
+                                implements Commands {
+                }
+
+                record Cancel(
+                                String slotId, String participantId, ParticipantType participantType, String bookingId)
+                                implements Commands {
+                }
         }
 
-        @TypeName("participant-canceled")
-        record Canceled(
-                String slotId, String participantId, ParticipantType participantType, String bookingId)
-                implements Event {
-        }
-    }
+        public sealed interface Event {
+                @TypeName("marked-available")
+                record MarkedAvailable(String slotId, String participantId, ParticipantType participantType)
+                                implements Event {
+                }
 
-    @Override
-    public ParticipantSlotEntity.State applyEvent(ParticipantSlotEntity.Event event) {
-        // Supply your own implementation
-        return null;
-    }
+                @TypeName("unmarked-available")
+                record UnmarkedAvailable(String slotId, String participantId, ParticipantType participantType)
+                                implements Event {
+                }
+
+                @TypeName("participant-booked")
+                record Booked(
+                                String slotId, String participantId, ParticipantType participantType, String bookingId)
+                                implements Event {
+                }
+
+                @TypeName("participant-canceled")
+                record Canceled(
+                                String slotId, String participantId, ParticipantType participantType, String bookingId)
+                                implements Event {
+                }
+        }
+
+        @Override
+        public ParticipantSlotEntity.State applyEvent(ParticipantSlotEntity.Event event) {
+                // Supply your own implementation
+                return null;
+        }
 }

--- a/src/main/java/io/example/application/ParticipantSlotsView.java
+++ b/src/main/java/io/example/application/ParticipantSlotsView.java
@@ -1,6 +1,6 @@
 package io.example.application;
 
-import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.Consume;
 import akka.javasdk.annotations.Query;
 import akka.javasdk.view.TableUpdater;
@@ -13,7 +13,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ComponentId("view-participant-slots")
+@Component(id = "view-participant-slots")
 public class ParticipantSlotsView extends View {
 
     private static Logger logger = LoggerFactory.getLogger(ParticipantSlotsView.class);

--- a/src/main/java/io/example/application/README.md
+++ b/src/main/java/io/example/application/README.md
@@ -5,3 +5,4 @@ In this folder you will need to implement 4 akka components:
 * `ParticipantSlotEntity` - A derived entity that stores the status of a participant within a given slot (e.g. `available` or `booked`).
 * `ParticipantSlotsView` - A view allowing queries of all slots for a given participant and slot
 * `SlotToParticipantConsumer` - A consumer that pulls events from the `BookingSlotEntity` and in turn sends commands to `ParticipantSlotEntity` to derive the participant-slot status.
+* `FlightConditionsAgent` - An AI agent responsible for checking and verifying flight conditions for the time of the booking.

--- a/src/main/java/io/example/application/SlotToParticipantConsumer.java
+++ b/src/main/java/io/example/application/SlotToParticipantConsumer.java
@@ -1,6 +1,6 @@
 package io.example.application;
 
-import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.Consume;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.consumer.Consumer;
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 // This class is responsible for consuming events from the booking
 // slot entity and turning those into command calls on the
 // participant slot entity
-@ComponentId("booking-slot-consumer")
+@Component(id = "booking-slot-consumer")
 @Consume.FromEventSourcedEntity(BookingSlotEntity.class)
 public class SlotToParticipantConsumer extends Consumer {
 


### PR DESCRIPTION
This adds some doc clarity and makes the following changes:

* Cert is now explicit about the format of time slots (`YYYY-MM-DD-HH`)
* Cert now requires an agent to verify flight conditions for a given time slot ID
  * Agent uses a local function tool to query/mock weather conditions
  * Agent class empty scaffold is included in `src/main/java/.../application/FlightConditionsAgent.java`
* Cert docs are now clear that unit/integration tests must pass _only if you supply them_
  * Docs indicate judges will use a curl/shell script to verify the service behavior
* Docs no longer refer to things that do not exist  
